### PR TITLE
Set default language to 'English', remove 'display language' from toggle-menu and ignore the browser language on login page.

### DIFF
--- a/src/branding/netfield/branding.css
+++ b/src/branding/netfield/branding.css
@@ -278,6 +278,11 @@ mark {
   color: var(--hil-variant1) !important;
 }
 
+/* Session toggle-menu  */
+.display-language-menu {
+  display: none;
+}
+
 /* sidebar */
 .pf-v5-c-text-input-group__text {
   background-color: var(--primary-variant2);
@@ -623,7 +628,6 @@ button.pf-v5-c-button.pf-m-link:hover {
   .pf-v5-theme-dark .pf-v5-c-alert.pf-m-inline.pf-m-danger {
     color: var(--primary-main) !important;
     width: 384px;
-    /* max-width: calc(100vw - 48px); */
     max-width: 20rem;
     overflow: hidden;
     line-height: 1.5714285714285714;
@@ -658,7 +662,6 @@ button.pf-v5-c-button.pf-m-link:hover {
     --hil-variant5: var(--secondary-variant5);
     --secondary-variant6: var(--secondary-variant6);
     --button-hover: var(--primary-variant1);
-    /* --blur-hil-variant2: var(--secondary-main); */
   }
 
   /* sidebar */

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -434,6 +434,12 @@ cockpit_web_server_parse_cookie (GHashTable *headers,
   gint diff;
   gint offset;
 
+  
+  // Hilscher specific
+  // ignore 'CockpitLang' cookie and set default language to 'en'
+  if (g_str_equal (name, "CockpitLang"))
+    return g_strdup ("en");
+
   header = g_hash_table_lookup (headers, "Cookie");
   if (!header)
     return NULL;


### PR DESCRIPTION
The 'accept-language' property provided by the request header is no longer output. This means that all text on the login page is translated into English.
The settings for language selection have been hidden in the html so that the user cannot change the 'CockpitLang' cookie in the browser to change the cockpit language.
So the listed languages 'locales' in 'pkg/shell/manifest.json' have also no influence anymore.