### PR TITLE
Render hardware details footer conditionally for better user experien…

### DIFF
--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -134,11 +134,19 @@ export class SystemInformationCard extends React.Component {
                         </tbody>
                     </table>
                 </CardBody>
-                <CardFooter>
-                    <Button isInline variant="link" component="a" onClick={ev => { ev.preventDefault(); cockpit.jump("/system/hwinfo", cockpit.transport.host) }}>
-                        {_("View hardware details")}
-                    </Button>
-                </CardFooter>
+                {/*
+                 * Some devices, especially many ARM systems, do not support DMI/DeviceTree
+                 * hardware information. Only render the hardware details footer when a model
+                 * string was successfully obtained. This is a better user experience than showing
+                 * a link that leads to an empty page.
+                 */}
+                {this.state.model && (
+                    <CardFooter>
+                        <Button isInline variant="link" component="a" onClick={ev => { ev.preventDefault(); cockpit.jump("/system/hwinfo", cockpit.transport.host) }}>
+                            {_("View hardware details")}
+                        </Button>
+                    </CardFooter>
+                )}
             </Card>
         );
     }


### PR DESCRIPTION
Conditionally hiding the hardware details footer on this.state.model prevents navigation to /system/hwinfo on systems without DMI/DeviceTree, even though that page still provides useful data (at least CPU info is always populated in pkg/systemd/hw-detect.js). This also contradicts the existing testHardwareInfo flow in test/verify/check-system-info, which explicitly mounts an empty /sys/class/dmi/id and still expects the hardware details link to be present and usable.

If the goal is to avoid an actually empty hardware info page, the condition should be based on whether /system/hwinfo has any content (requires plumbing that state here). As-is, this is a functional regression; simplest fix is to keep the footer link unconditionally rendered.